### PR TITLE
Added way of handling mouseEvents separated from the InputEvents

### DIFF
--- a/FS19_simpleIC/registerSimpleIC.lua
+++ b/FS19_simpleIC/registerSimpleIC.lua
@@ -32,37 +32,22 @@ function registerSimpleIC.installSpecializations(vehicleTypeManager, specializat
 
 end
 
-
-
 init()
 
+function registerSimpleIC:mouseEvent(posX, posY, isDown, isUp, button)
+	if isUp then
+		local vehicle = g_currentMission.controlledVehicle
 
+		--Check if this is the key assigned to INTERACT
+		local action = g_inputBinding:getActionByName("INTERACT_IC_VEHICLE");
+		for _, binding in ipairs(action.bindings) do
+			if binding.axisNames[1] ~= nil and binding.axisNames[1] == Input.mouseButtonIdToIdName[button] then
+				if vehicle ~= nil and vehicle.spec_simpleIC ~= nil then
+					simpleIC.doInteraction(vehicle)
+				end
+			end
+		end
+	end
+end
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+addModEventListener(registerSimpleIC)

--- a/FS19_simpleIC/simpleIC.lua
+++ b/FS19_simpleIC/simpleIC.lua
@@ -74,6 +74,7 @@ function simpleIC:onLoad(savegame)
 	self.updateActionEventsSIC = simpleIC.updateActionEventsSIC;
 	self.setICState = simpleIC.setICState;
 	self.resetCanBeTriggered = simpleIC.resetCanBeTriggered;
+	self.doInteraction = simpleIC.doInteraction;
 
 	self.spec_simpleIC = {};
 	
@@ -291,7 +292,16 @@ function simpleIC:onDelete()
 end;
 
 function simpleIC:INTERACT(actionName, inputValue)
+	self:doInteraction()
+end;
+
+function simpleIC:doInteraction()
 	local spec = self.spec_simpleIC;
+	--Prevent two events if mouseEvent is triggering and the InputBinding (is not used twice)
+	if spec ~= nil and spec.actedThisFrame then
+		return
+	end
+
 	if spec ~= nil and spec.hasIC then
 		if spec.icTurnedOn_inside or spec.icTurnedOn_outside or spec.playerInOutsideInteractionTrigger then
 			local i = 1;
@@ -316,7 +326,7 @@ function simpleIC:INTERACT(actionName, inputValue)
 			end;	
 		end;
 	end;
-end;
+end
 
 function simpleIC:TOGGLE_ONOFF(actionName, inputValue)
 	local spec = self.spec_simpleIC;
@@ -373,6 +383,7 @@ function simpleIC:onUpdate(dt)
 	if self.spec_simpleIC ~= nil and self.spec_simpleIC.hasIC then
 
 		local spec = self.spec_simpleIC;
+		spec.actedThisFrame = false;
 		if self.spec_simpleIC.playerInOutsideInteractionTrigger then
 			self:checkInteraction()
 			self:raiseActive() -- keep vehicle awake as long as player is in trigger 


### PR DESCRIPTION
This works for the vehicle camera.
Other mods which also use the mouse button and thus block simpleIC from receiving this event. now no longer worry simpleIC.

I don't have all the insights into the internal workings of the Giants engine. But this should at least do the trick and help you keep user complaints down a little :-)
I just saw your video on youtube and thought this could be 'hacked' a little.
If you also add a keyListener, you could also work around general double mappings of buttons.

No worry If you don't like it. I just wanted to offer you one way of doing it :-)

Oh and I love the great work you are doing for the FS community :-)

Greetings,
Stephan 